### PR TITLE
Fix: Use Twingate resource name for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,11 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+          ssh-keyscan -H beefsteak >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Deploy to server
         run: |
-          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} << 'DEPLOY_SCRIPT'
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@beefsteak << 'DEPLOY_SCRIPT'
           cd /home/hungry/ciahackedme
           git pull origin main
           npm install


### PR DESCRIPTION
Fix deployment to use Twingate resource name instead of direct IP.

Changed from:
- `${{ secrets.DEPLOY_HOST }}` (192.168.12.183)

Changed to:
- `beefsteak` (Twingate resource name)

This allows GitHub Actions to connect through Twingate Zero Trust instead of directly to the IP address. Since you're logged into Twingate with your GitHub account, GitHub Actions will have access to the beefsteak resource.