### PR TITLE
Add Twingate API authentication to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,15 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H beefsteak >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      - name: Authenticate with Twingate
+        run: |
+          # Download and install Twingate CLI
+          curl -s https://repo.twingate.com/cli/releases/twingate-latest-linux-amd64.tar.gz | tar xz -C /tmp
+          /tmp/twingate version
+          
+          # Authenticate with Twingate using API token
+          /tmp/twingate login --api-token "${{ secrets.TWINGATE_API_TOKEN }}" --account beeboos
+
       - name: Deploy to server
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@beefsteak << 'DEPLOY_SCRIPT'


### PR DESCRIPTION
Add Twingate API authentication to deployment workflow.

## What changed:
- Added Twingate CLI authentication step before SSH deployment
- Uses the `TWINGATE_API_TOKEN` secret to authenticate
- CLI logs in to the `beeboos` Twingate account
- Once authenticated, SSH can connect through Twingate to `beefsteak`

## How it works:
1. GitHub Actions downloads Twingate CLI
2. Authenticates using your API token
3. SSH connection to beefsteak is established through authenticated Twingate session
4. Deployment proceeds as normal

This is more secure than direct IP access and leverages your Zero Trust setup properly.