### PR TITLE
Test deployment with direct IP address

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,11 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H 192.168.12.183 >> ~/.ssh/known_hosts 2>/dev/null || true
 
-      - name: Deploy to server via Twingate
-        env:
-          TWINGATE_API_TOKEN: ${{ secrets.TWINGATE_API_TOKEN }}
+      - name: Deploy to server
         run: |
-          # SSH to beefsteak through Twingate connection
-          # The API token is used by Twingate to authenticate this session
-          ssh -v -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new ${{ secrets.DEPLOY_USER }}@beefsteak << 'DEPLOY_SCRIPT'
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@192.168.12.183 << 'DEPLOY_SCRIPT'
           cd /home/hungry/ciahackedme
           git pull origin main
           npm install


### PR DESCRIPTION
Try deployment using direct IP address instead of hostname.

Changed from: `beefsteak` (hostname)
Changed to: `192.168.12.183` (direct IP)

This tests if the SSH connection works with the direct IP. If it does, we can either:
1. Keep it as-is with the IP
2. Set up a Twingate alias hostname for better long-term use

Let's see if the direct IP works first!