### PR TITLE
Use official Twingate GitHub Action for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Connect to Twingate
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+          service-key-id: ${{ secrets.TWINGATE_SERVICE_KEY_ID }}
+          access-token: ${{ secrets.TWINGATE_API_TOKEN }}
+
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh


### PR DESCRIPTION
Use official Twingate GitHub Action for deployment connectivity.

## What changed:
- Added official Twingate GitHub Action before SSH deployment
- Uses service account credentials to authenticate with Twingate
- Establishes Twingate connection context for GitHub Actions runner
- SSH can now connect through Twingate to 192.168.12.183

## How it works:
1. GitHub Action connects to Twingate using service account credentials
2. Twingate tunnel is established for this runner
3. SSH connection to your home server works through the tunnel
4. Deployment proceeds normally

## Secrets used:
- `TWINGATE_SERVICE_KEY_ID` - Service account key ID
- `TWINGATE_SERVICE_KEY` - Service account private key
- `TWINGATE_API_TOKEN` - API token (already had)
- `DEPLOY_KEY` - SSH private key (already had)

This is the official, supported way to use Twingate with GitHub Actions!